### PR TITLE
dnsdb_query.py: handle slashes in rname, bailiwick, rdata

### DIFF
--- a/dnsdb_query.py
+++ b/dnsdb_query.py
@@ -22,6 +22,7 @@ import os
 import re
 import sys
 import time
+import urllib
 import urllib2
 from cStringIO import StringIO
 
@@ -70,19 +71,19 @@ class DnsdbClient(object):
         res = []
         url = '%s/lookup/%s' % (self.server, path)
 
-        params = []
+        params = {}
         if self.limit:
-            params.append('limit=%d' % self.limit)
+            params['limit'] = self.limit
         if before and after:
-            params.append('time_first_after=%d' % after)
-            params.append('time_last_before=%d' % before)
+            params['time_first_after'] = after
+            params['time_last_before'] = before
         else:
             if before:
-                params.append('time_first_before=%d' % before)
+                params['time_first_before'] = before
             if after:
-                params.append('time_last_after=%d' % after)
+                params['time_last_after'] = after
         if params:
-            url += '?{0}'.format('&'.join(params))
+            url += '?{0}'.format(urllib.urlencode(params))
 
         req = urllib2.Request(url)
         req.add_header('Accept', 'application/json')


### PR DESCRIPTION
ref issue #5

```
$ ./dnsdb_query.py -r "226.0/24.75.70.64.in-addr.arpa/PTR/0/24.75.70.64.in-addr.arpa"
;;  bailiwick: 0/24.75.70.64.in-addr.arpa.
;;      count: 0
;; first seen: 2014-02-26 01:08:25 -0000
;;  last seen: 2014-02-26 01:08:25 -0000
226.0/24.75.70.64.in-addr.arpa. IN PTR t226.rent.com.
```

URL was `http://localhost:8080/lookup/rrset/name/226.0%2F24.75.70.64.in-addr.arpa/PTR/0%2F24.75.70.64.in-addr.arpa`

```
$ ./dnsdb_query.py -r "226.0/24.75.70.64.in-addr.arpa/PTR"
;;  bailiwick: 0/24.75.70.64.in-addr.arpa.
;;      count: 0
;; first seen: 2014-02-26 01:08:25 -0000
;;  last seen: 2014-02-26 01:08:25 -0000
226.0/24.75.70.64.in-addr.arpa. IN PTR t226.rent.com.
```

URL was `http://localhost:8080/lookup/rrset/name/226.0%2F24.75.70.64.in-addr.arpa/PTR`

```
$ ./dnsdb_query.py -r "226.0/24.75.70.64.in-addr.arpa/PTR/"
;;  bailiwick: 0/24.75.70.64.in-addr.arpa.
;;      count: 0
;; first seen: 2014-02-26 01:08:25 -0000
;;  last seen: 2014-02-26 01:08:25 -0000
226.0/24.75.70.64.in-addr.arpa. IN PTR t226.rent.com.
```

URL was `http://localhost:8080/lookup/rrset/name/226.0%2F24.75.70.64.in-addr.arpa/PTR`

```
$ ./dnsdb_query.py -r "226.0/24.75.70.64.in-addr.arpa"
;;  bailiwick: 0/24.75.70.64.in-addr.arpa.
;;      count: 0
;; first seen: 2014-02-26 01:08:25 -0000
;;  last seen: 2014-02-26 01:08:25 -0000
226.0/24.75.70.64.in-addr.arpa. IN PTR t226.rent.com.
```

URL was `http://localhost:8080/lookup/rrset/name/226.0%2F24.75.70.64.in-addr.arpa`