### PR TITLE
dnsdb_query.py: time_parse raises ValueError

### DIFF
--- a/dnsdb_query.py
+++ b/dnsdb_query.py
@@ -151,6 +151,8 @@ def time_parse(s):
     except ValueError:
         pass
 
+    raise ValueError, 'Invalid time: "%s"' % s
+
 def filter_before(res_list, before_time):
     before_time = time_parse(before_time)
     new_res_list = []


### PR DESCRIPTION
time_parse(s) silently returned None instead of raising a ValueError if passed invalid input
