### PR TITLE
New option when emiting JSON to add an ISO 8601 timestamp, bug fix for JSON+time filtering options

### DIFF
--- a/dnsdb_query.py
+++ b/dnsdb_query.py
@@ -191,6 +191,29 @@ def filter_after(res_list, after_time, do_json):
 
     return new_res_list
 
+def human_time(res_list):
+    new_res_list = []
+    newline = False
+
+    for res in res_list:
+        res = json.loads(res)
+        if 'time_first' in res:
+            res['time_first'] = sec_to_text(res['time_first'])
+        elif 'zone_time_first' in res:
+            res['zone_time_first'] = sec_to_text(res['zone_time_first'])
+        if 'time_last' in res:
+            res['time_last'] = sec_to_text(res['time_last'])
+            newline = True
+        elif 'zone_time_last' in res:
+            res['zone_time_last'] = sec_to_text(res['zone_time_last'])
+            newline = True
+        new_res_list.append(json.dumps(res))
+        if newline == True:
+            new_res_list.append("\n")
+
+    return new_res_list
+
+
 def main():
     global cfg
     global options
@@ -211,6 +234,8 @@ def main():
         help='output in JSON format')
     parser.add_option('-l', '--limit', dest='limit', type='int', default=0,
         help='limit number of results')
+    parser.add_option('-H', '--human_time', dest='htime', action='store_true', default=False,
+        help='when emiting json, write time in human readable format instead of unix epoch')
 
     parser.add_option('', '--before', dest='before', type='string', help='only output results seen before this time')
     parser.add_option('', '--after', dest='after', type='string', help='only output results seen after this time')
@@ -257,6 +282,8 @@ def main():
             res_list = filter_before(res_list, options.before, options.json)
         if options.after:
             res_list = filter_after(res_list, options.after, options.json)
+        if options.json and options.htime:
+            res_list = human_time(res_list)
 
     for res in res_list:
         sys.stdout.write(fmt_func(res))

--- a/dnsdb_query.py
+++ b/dnsdb_query.py
@@ -164,7 +164,7 @@ def filter_before(res_list, before_time, do_json):
             if res2['time_first'] < before_time:
                 new_res_list.append(res)
         elif 'zone_time_first' in res2:
-            if res['zone_time_first'] < before_time:
+            if res2['zone_time_first'] < before_time:
                 new_res_list.append(res)
         else:
             new_res_list.append(res)
@@ -184,7 +184,7 @@ def filter_after(res_list, after_time, do_json):
             if res2['time_last'] > after_time:
                 new_res_list.append(res)
         elif 'zone_time_last' in res:
-            if res['zone_time_last'] > after_time:
+            if res2['zone_time_last'] > after_time:
                 new_res_list.append(res)
         else:
             new_res_list.append(res)

--- a/dnsdb_query.py
+++ b/dnsdb_query.py
@@ -193,31 +193,14 @@ def filter_after(res_list, after_time, do_json):
 
 def human_time(res_list):
     new_res_list = []
-    #newline = False
 
     for res in res_list:
         res = json.loads(res)
         for field in ("time_first", "zone_time_first", "time_last", "zone_time_last"):
             if field in res:
                 res[field + "_iso8601"] = sec_to_text(res[field])
-            new_res_list.append(json.dumps(res))
-        return new_res_list
-"""
-        if 'time_first' in res:
-            res['time_first' + '_iso8601'] = sec_to_text(res['time_first'])
-        elif 'zone_time_first' in res:
-            res['zone_time_first' + '_iso8601'] = sec_to_text(res['zone_time_first'])
-        if 'time_last' in res:
-            res['time_last' + '_iso8601'] = sec_to_text(res['time_last'])
-            newline = True
-        elif 'zone_time_last' in res:
-            res['zone_time_last' + '_iso8601'] = sec_to_text(res['zone_time_last'])
-            newline = True
-        new_res_list.append(json.dumps(res))
-        if newline == True:
-            new_res_list.append("\n")
+        new_res_list.append(json.dumps(res) + "\n")
     return new_res_list
-"""
 
 def main():
     global cfg

--- a/dnsdb_query.py
+++ b/dnsdb_query.py
@@ -193,26 +193,31 @@ def filter_after(res_list, after_time, do_json):
 
 def human_time(res_list):
     new_res_list = []
-    newline = False
+    #newline = False
 
     for res in res_list:
         res = json.loads(res)
+        for field in ("time_first", "zone_time_first", "time_last", "zone_time_last"):
+            if field in res:
+                res[field + "_iso8601"] = sec_to_text(res[field])
+            new_res_list.append(json.dumps(res))
+        return new_res_list
+"""
         if 'time_first' in res:
-            res['time_first'] = sec_to_text(res['time_first'])
+            res['time_first' + '_iso8601'] = sec_to_text(res['time_first'])
         elif 'zone_time_first' in res:
-            res['zone_time_first'] = sec_to_text(res['zone_time_first'])
+            res['zone_time_first' + '_iso8601'] = sec_to_text(res['zone_time_first'])
         if 'time_last' in res:
-            res['time_last'] = sec_to_text(res['time_last'])
+            res['time_last' + '_iso8601'] = sec_to_text(res['time_last'])
             newline = True
         elif 'zone_time_last' in res:
-            res['zone_time_last'] = sec_to_text(res['zone_time_last'])
+            res['zone_time_last' + '_iso8601'] = sec_to_text(res['zone_time_last'])
             newline = True
         new_res_list.append(json.dumps(res))
         if newline == True:
             new_res_list.append("\n")
-
     return new_res_list
-
+"""
 
 def main():
     global cfg
@@ -235,7 +240,7 @@ def main():
     parser.add_option('-l', '--limit', dest='limit', type='int', default=0,
         help='limit number of results')
     parser.add_option('-H', '--human_time', dest='htime', action='store_true', default=False,
-        help='when emiting json, write time in human readable format instead of unix epoch')
+        help='when emiting json, add an ISO 8601 human readable timestamp, set to UTC')
 
     parser.add_option('', '--before', dest='before', type='string', help='only output results seen before this time')
     parser.add_option('', '--after', dest='after', type='string', help='only output results seen after this time')

--- a/dnsdb_query.py
+++ b/dnsdb_query.py
@@ -87,8 +87,9 @@ class DnsdbClient(object):
             sys.stderr.write(str(e) + '\n')
         return res
 
-def sec_to_text(ts):
-    return time.strftime('%Y-%m-%d %H:%M:%S -0000', time.gmtime(ts))
+def sec_to_text(ts, do_8601=False):
+
+    return time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime(ts))  if do_8601 else time.strftime('%Y-%m-%d %H:%M:%S -0000', time.gmtime(ts))
 
 def rrset_to_text(m):
     s = StringIO()
@@ -198,7 +199,7 @@ def human_time(res_list):
         res = json.loads(res)
         for field in ("time_first", "zone_time_first", "time_last", "zone_time_last"):
             if field in res:
-                res[field + "_iso8601"] = sec_to_text(res[field])
+                res[field + "_iso8601"] = sec_to_text(res[field], do_8601=True)
         new_res_list.append(json.dumps(res) + "\n")
     return new_res_list
 

--- a/dnsdb_query.py
+++ b/dnsdb_query.py
@@ -197,10 +197,10 @@ def human_time(res_list):
 
     for res in res_list:
         res = json.loads(res)
-        for field in ("time_first", "zone_time_first", "time_last", "zone_time_last"):
+        for field in ('time_first', 'zone_time_first', 'time_last', 'zone_time_last'):
             if field in res:
-                res[field + "_iso8601"] = sec_to_text(res[field], do_8601=True)
-        new_res_list.append(json.dumps(res) + "\n")
+                res[field + '_iso8601'] = sec_to_text(res[field], do_8601=True)
+        new_res_list.append(json.dumps(res) + '\n')
     return new_res_list
 
 def main():
@@ -234,7 +234,11 @@ def main():
         parser.print_help()
         sys.exit(1)
 
-    cfg = parse_config(options.config)
+    try:
+         cfg = parse_config(options.config)
+    except IOError, e:
+         sys.stderr.write(e.message)
+         sys.exit(1)
 
     if not 'DNSDB_SERVER' in cfg:
         cfg['DNSDB_SERVER'] = DEFAULT_DNSDB_SERVER

--- a/dnsdb_query.py
+++ b/dnsdb_query.py
@@ -151,15 +151,19 @@ def time_parse(s):
     except ValueError:
         pass
 
-def filter_before(res_list, before_time):
+def filter_before(res_list, before_time, do_json):
     before_time = time_parse(before_time)
     new_res_list = []
 
     for res in res_list:
-        if 'time_first' in res:
-            if res['time_first'] < before_time:
+        if do_json is True:
+            res2 = json.loads(res)
+        else:
+            res2 = res
+        if 'time_first' in res2:
+            if res2['time_first'] < before_time:
                 new_res_list.append(res)
-        elif 'zone_time_first' in res:
+        elif 'zone_time_first' in res2:
             if res['zone_time_first'] < before_time:
                 new_res_list.append(res)
         else:
@@ -167,13 +171,17 @@ def filter_before(res_list, before_time):
 
     return new_res_list
 
-def filter_after(res_list, after_time):
+def filter_after(res_list, after_time, do_json):
     after_time = time_parse(after_time)
     new_res_list = []
 
     for res in res_list:
-        if 'time_last' in res:
-            if res['time_last'] > after_time:
+        if do_json is True:
+            res2 = json.loads(res)
+        else:
+            res2 = res
+        if 'time_last' in res2:
+            if res2['time_last'] > after_time:
                 new_res_list.append(res)
         elif 'zone_time_last' in res:
             if res['zone_time_last'] > after_time:
@@ -246,9 +254,9 @@ def main():
                 sys.exit(1)
             res_list.sort(key=lambda r: r[options.sort], reverse=options.reverse)
         if options.before:
-            res_list = filter_before(res_list, options.before)
+            res_list = filter_before(res_list, options.before, options.json)
         if options.after:
-            res_list = filter_after(res_list, options.after)
+            res_list = filter_after(res_list, options.after, options.json)
 
     for res in res_list:
         sys.stdout.write(fmt_func(res))


### PR DESCRIPTION
Two patches to code:
1. Bug fix for crash when combining --json with --before/--after options:
```
./dnsdb_query.py --before 1358051711 --after 1358051709 --json -r cisco.com/A
{"count": 79286, "time_first": 1358051710, "rrtype": "A", "rrname": "cisco.com.", "bailiwick": "cisco.com.", "rdata": ["72.163.4.161"], "time_last": 1394039207}
```

2. New option to add an ISO 8601 timestamp (set to UTC) to the output when emitting JSON:
```
./dnsdb_query.py --human_time --json -r cisco.com/A
{"count": 79286, "time_first": 1358051710, "time_first_iso8601": "2013-01-13T04:35:10Z", "rrtype": "A", "rrname": "cisco.com.", "bailiwick": "cisco.com.", "rdata": ["72.163.4.161"], "time_last": 1394039207, "time_last_iso8601": "2014-03-05T17:06:47Z"}
{"count": 1, "time_first": 1331587834, "time_first_iso8601": "2012-03-12T21:30:34Z", "rrtype": "A", "rrname": "cisco.com.", "bailiwick": "cisco.com.", "rdata": ["172.19.25.68", "198.133.219.25"], "time_last": 1331587834, "time_last_iso8601": "2012-03-12T21:30:34Z"}
{"count": 150120, "time_first": 1277354894, "time_first_iso8601": "2010-06-24T04:48:14Z", "rrtype": "A", "rrname": "cisco.com.", "bailiwick": "cisco.com.", "rdata": ["198.133.219.25"], "time_last": 1358050608, "time_last_iso8601": "2013-01-13T04:16:48Z"}
 ```