### PR TITLE
Fix error: "IOError: [Errno 32] Broken pipe"

### DIFF
--- a/dnsdb_query.py
+++ b/dnsdb_query.py
@@ -24,6 +24,7 @@ import sys
 import time
 import urllib
 import urllib2
+from signal import signal, SIGPIPE, SIG_DFL
 from cStringIO import StringIO
 
 try:
@@ -280,6 +281,7 @@ def main():
                     sys.exit(1)
                 results.sort(key=lambda r: r[options.sort], reverse=options.reverse)
         for res in results:
+            signal(SIGPIPE, SIG_DFL)
             sys.stdout.write('%s\n' % fmt_func(res))
     except QueryError, e:
         print >>sys.stderr, e.message


### PR DESCRIPTION
Issue: IOError: [Errno 32] Broken pipe

Example:

```
$ python dnsdb_query.py -n *.fsi.io | head -n 10
...
Traceback (most recent call last):
  File "dnsdb_query.py", line 289, in <module>
    main()
  File "dnsdb_query.py", line 283, in main
    sys.stdout.write('%s\n' % fmt_func(res))
IOError: [Errno 32] Broken pipe
```

References:

http://stackoverflow.com/questions/14207708/ioerror-errno-32-broken-pipe-python/35761190#35761190

https://github.com/pypa/pip/pull/3304/commits/b55d84986fb0f9607f3039d1a525432f5ec487e4