### PR TITLE
Python 3 instead of 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Requirements
 ------------
  * Linux, BSD, OS X
  * Curl
- * Python 2.7.x
+ * Python 3.x
  * Farsight DNSDB API key
 
 Installation

--- a/dnsdb_query.py
+++ b/dnsdb_query.py
@@ -92,7 +92,13 @@ class DnsdbClient(object):
         if params:
             url += '?{0}'.format(urllib.parse.urlencode(params))
 
-        http = urllib3.PoolManager()
+        if self.https_proxy:
+            manager = urllib3.ProxyManager(self.https_proxy)
+        elif self.http_proxy:
+            manager = urllib3.ProxyManager(self.http_proxy)
+        else:
+            manager = urllib3.PoolManager()
+
         headers = {
             'Accept': 'application/json',
             'X-Api-Key': self.apikey
@@ -102,7 +108,7 @@ class DnsdbClient(object):
             sys.stderr.write(";; query URL =" + url)
 
         try:
-            r = http.request('GET', url, headers=headers)
+            r = manager.request(method='GET', url=url, headers=headers)
 
             json_data = r.data.decode('utf-8')
             if json_data:


### PR DESCRIPTION
In commit 078aae4 Python v3 support was reverted due to some issues with 2.7, but as 2.7 is now EOL we can start to drop 2.7  support.